### PR TITLE
Add support for parsing multiple XTCE files

### DIFF
--- a/test-xtce-files/multi-dt.xml
+++ b/test-xtce-files/multi-dt.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SpaceSystem name="base-dt" xmlns:xtce="http://www.omg.org/spec/XTCE/20180204"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.omg.org/spec/XTCE/20180204 https://www.omg.org/spec/XTCE/20180204/SpaceSystem.xsd"
+	operationalStatus="unittest">
+	<TelemetryMetaData>
+		<ParameterTypeSet>
+			<IntegerParameterType name="uint8_t" signed="false">
+				<IntegerDataEncoding encoding="unsigned" sizeInBits="8" />
+			</IntegerParameterType>
+			<IntegerParameterType name="int16_t" signed="true">
+				<IntegerDataEncoding encoding="twosComplement" sizeInBits="16" />
+			</IntegerParameterType>
+		</ParameterTypeSet>
+	</TelemetryMetaData>
+
+	<CommandMetaData>
+		<ArgumentTypeSet>
+		</ArgumentTypeSet>
+	</CommandMetaData>
+</SpaceSystem>

--- a/test-xtce-files/multi-pkt.xml
+++ b/test-xtce-files/multi-pkt.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="xtce_template.xsl"?>
+<xtce:SpaceSystem name="multi-pkt" 
+    xmlns:xtce="http://www.omg.org/spec/XTCE/20180204" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.omg.org/spec/XTCE/20180204 https://www.omg.org/spec/XTCE/20180204/SpaceSystem.xsd" 
+    shortDescription="Testing xtce-rs processing" 
+    operationalStatus="unittest">
+
+	<xtce:TelemetryMetaData>
+		<xtce:ParameterSet>
+			<xtce:Parameter name="param1-signed16" parameterTypeRef="/base-dt/int16_t" />
+		</xtce:ParameterSet>
+		<xtce:ContainerSet>
+			<xtce:SequenceContainer name="packet-signedint">
+				<xtce:EntryList>
+					<xtce:ParameterRefEntry parameterRef="param1-signed16" />
+				</xtce:EntryList>
+			</xtce:SequenceContainer>
+		</xtce:ContainerSet>
+	</xtce:TelemetryMetaData>
+</xtce:SpaceSystem>

--- a/tests/multixtce.rs
+++ b/tests/multixtce.rs
@@ -1,0 +1,37 @@
+use std::path::Path;
+
+use xtce_rs::{mdb::MissionDatabase, parser, proc::containers::process};
+
+static INIT: std::sync::Once = std::sync::Once::new();
+
+pub fn init_logging() {
+    INIT.call_once(|| {
+        env_logger::init();
+    });
+}
+
+
+fn init_multi_mdb() -> MissionDatabase {
+    init_logging();
+
+    let paths = [
+        "test-xtce-files/multi-dt.xml",
+        "test-xtce-files/multi-pkt.xml"
+    ].map(Path::new);
+    
+    parser::parse_files(&paths)
+        .expect("multixtce files should be valid")
+}
+
+#[test]
+fn type_defined_in_different_file() {
+    let mdb = init_multi_mdb();
+
+    let packet: Vec<u8> = vec![0xff, 0xef];
+
+    let root_container = mdb.search_container("/multi-pkt/packet-signedint").unwrap();
+    let r = process(&mdb, &packet, root_container).unwrap();
+
+    assert_eq!(1, r.len());
+    assert_eq!("-17", r[0].eng_value.to_string());
+}


### PR DESCRIPTION
Closes #1. Seems to work for a very simple case. Not yet tested with the ACubeSAT XTCE files.

Note: there may be a more rust-idiomatic way of reading the XTCE files and creating `roxmltree::Document`s. The problem is that Document borrows the XML content string, so the content needs to be stored in a Vec first, and then we can create Document instances. Suggestions to make this better welcome.