### PR TITLE
Add BitWriter

### DIFF
--- a/src/bitbuffer.rs
+++ b/src/bitbuffer.rs
@@ -165,7 +165,7 @@ impl BitBuffer<'_> {
 
     pub fn get_byte(&mut self) -> u8 {
         self.ensure_byte_boundary();
-        let r = self.b[self.position/8];
+        let r = self.b[self.position / 8];
         self.position += 8;
         r
     }
@@ -184,8 +184,8 @@ impl BitBuffer<'_> {
     /// advances the position
     /// panics if there is not enough data in the buffer
     pub fn get_bytes_ref(&mut self, len: usize) -> &[u8] {
-        let pos = self.position/8;
-        self.position =  self.position + 8*len;
+        let pos = self.position / 8;
+        self.position = self.position + 8 * len;
         &self.b[pos..pos + len]
     }
 
@@ -250,7 +250,6 @@ mod tests {
 
         assert_eq!(0x18, bitbuf.get_byte());
         assert_eq!([0x7A, 0x23, 0xFF], bitbuf.get_bytes_ref(3));
-
     }
 
     #[test]

--- a/src/bitbuffer.rs
+++ b/src/bitbuffer.rs
@@ -202,6 +202,71 @@ impl BitBuffer<'_> {
     }
 }
 
+pub struct BitWriter<'a> {
+    b: &'a mut [u8],
+    position: usize,
+    byte_order: ByteOrder,
+}
+
+impl<'a> BitWriter<'a> {
+    pub fn wrap(b: &'a mut [u8]) -> BitWriter<'a> {
+        Self { b: b, position: 0, byte_order: ByteOrder::BigEndian }
+    }
+
+    pub fn write_bits(&mut self, value: u64, num_bits: usize) {
+        if self.byte_order == ByteOrder::LittleEndian {
+            todo!(); // is this actually needed?
+        }
+
+        let mut pos = self.position;
+        let mut byte_pos = pos / 8;
+        let mut n = num_bits;
+        let mut v = value;
+
+        // TODO slice bounds check
+
+        let fbb = (-(pos as i32) & 0x7) as usize; // how many bits are from position until the end of the byte
+        if fbb > 0 {
+            if n <= fbb {
+                // the value fits entirely within the first byte
+                let mask: u8 = (1 << n) - 1;
+                self.b[byte_pos] &= !(mask << (fbb - n)); // clear existing bits that may be set
+                self.b[byte_pos] |= ((v as u8) & mask) << (fbb - n); // set requested bits
+                pos += num_bits;
+                self.position = pos;
+                return;
+            } else {
+                let mask = (1 << fbb) - 1;
+                self.b[byte_pos] &= !mask; // clear existing bits that may be set
+                self.b[byte_pos] |= (v >> (n - fbb)) as u8 & mask; // set requested bits
+                n -= fbb;
+                byte_pos += 1;
+                v &= (1 << n) - 1;
+            }
+        }
+
+        while n >= 8 {
+            n -= 8;
+            self.b[byte_pos] = (v >> n) as u8;
+            byte_pos += 1;
+            v &= (1 << n) - 1;
+        }
+
+        if n > 0 {
+            let mask = (1 << n) - 1;
+            self.b[byte_pos] &= !(mask << (8 - n));
+            self.b[byte_pos] |= (v as u8) << (8 - n);
+        }
+
+        pos += num_bits;
+        self.position = pos;
+    }
+
+    pub fn set_byte_order(&mut self, byte_order: ByteOrder) {
+        self.byte_order = byte_order;
+    }
+}
+
 #[derive(PartialEq, Clone, Copy, Debug)]
 pub enum ByteOrder {
     BigEndian,
@@ -215,6 +280,22 @@ mod tests {
     use rand::{rngs::SmallRng, RngCore, SeedableRng};
 
     use super::*;
+
+    #[test]
+    fn test_write_bigendian() {
+        let mut b: [u8; 4] = [0, 0, 0, 0];
+        let mut w = BitWriter::wrap(&mut b);
+
+        w.write_bits(5, 3);
+        w.write_bits(0xabcdef, 24);
+
+        assert_eq!([0xb5, 0x79, 0xbd, 0xe0], b);
+
+        let mut bb = BitBuffer::wrap(&b);
+
+        assert_eq!(5, bb.get_bits(3));
+        assert_eq!(0xabcdef, bb.get_bits(24));
+    }
 
     #[test]
     fn test_bigendian() {


### PR DESCRIPTION
I'm writing an application that uses xtce-rs to process commands coming from a yamcs instance and I'd like to also use it to write telemetry packets. So I added a new BitWriter struct. I tried to add this function to BitBuffer but Rust didn't like having an immutable reference and an `Option<&mut [u8]>` at the same time. 